### PR TITLE
[gallery downloader] fix download for new files

### DIFF
--- a/userjs/sims-4-gallery-downloader.user.js
+++ b/userjs/sims-4-gallery-downloader.user.js
@@ -7,6 +7,7 @@
 // @connect     sims4cdn.ea.com
 // @connect     athena.thesims.com
 // @connect     www.thesims.com
+// @connect     thesims-api.ea.com
 // @version     2.1.11
 // @namespace   anadius.github.io
 // @grant       unsafeWindow


### PR DESCRIPTION
When I tested the latest code, I found an error in Chrome: 
injected: Refused to connect to "https://thesims-api.ea.com/api/gallery/v1/sims/tWT2yZkQRFCjXm%2FntBhutg%3D%3D": This domain is not a part of the @connect list